### PR TITLE
Capitalize Addressable Type Fields in Seed Data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,26 +48,26 @@ class Seed
   end
 
   def generate_addresses
-    1.upto(101) do |i|
+    1.upto(100) do |i|
       Address.create!(
         type_of: 0,
         address_1: Faker::Address.street_address,
         city: Faker::Address.city,
         state: Faker::Address.state_abbr,
         zip_code: Faker::Address.zip_code.to_i,
-        addressable_type: "user",
+        addressable_type: "User",
         addressable_id: i 
       )
     end
 
-    1.upto(21) do |i|
+    1.upto(20) do |i|
       Address.create!(
         type_of: 0, 
         address_1: Faker::Address.street_address,
         city: Faker::Address.city,
         state: Faker::Address.state_abbr,
         zip_code: Faker::Address.zip_code.to_i,
-        addressable_type: "seller",
+        addressable_type: "Seller",
         addressable_id: i
       )
     end


### PR DESCRIPTION
Why:
- For polymorphic associations to work as needed. Before this change, rails wasn't recognizing the associations between sellers/users and the addresses table.

This change addresses the need by:
- Capitalizing the addressable type strings in the seed data

Other notes:
- The iterators in #generate_addresses (in seed.rb) were creating one more
  address than necessary so this was fixed as well.
