### PR TITLE
Remove 'require factory_helper' from spec

### DIFF
--- a/spec/features/admin_can_view_all_products_spec.rb
+++ b/spec/features/admin_can_view_all_products_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "factory_helper"
 
 feature "Admin can view all Products from Admin Dashboard" do
   before do


### PR DESCRIPTION
Necessary for rspec to run all tests since we deleted the factory_helper file.
